### PR TITLE
Parse CTM JSON from text in EGRET example

### DIFF
--- a/examples/scripts/EGRET_interface/ctm_uc_str_example.py
+++ b/examples/scripts/EGRET_interface/ctm_uc_str_example.py
@@ -1,0 +1,27 @@
+#  ___________________________________________________________________________
+# EGRET CTM extension example
+#  ___________________________________________________________________________
+
+## Example of solving a unit commitment problem from pglib-uc
+
+from egret.models.unit_commitment import solve_unit_commitment
+import ctminterface
+
+## Create an Egret 'ModelData' object, which is just a lightweight
+## wrapper around a python dictionary, from a CTM instance
+print('Creating and solving RTS GML 2020-01-27.json (with transmission) ...')
+with open('../../instances/unit_commitment_data/2020-01-27.json', 'r') as f:
+    json_text = f.read()
+md = ctminterface.create_ModelData(ctm_json_str=json_text)
+
+## solve the unit commitment instance using solver cbc -- could use 'gurobi', 'cplex',
+## or any valid Pyomo solver name, provided its available
+md_sol = solve_unit_commitment(md, 'cbc', mipgap=0.01, timelimit=300, solver_tee=True)
+print('Solved!')
+
+## print the objective value to the screen
+print('Objective value:', md_sol.data['system']['total_cost'])
+
+## write the solution to an Egret *.json file
+ctminterface.write_solution(md_sol, './2020-01-27_solution_from_text.json')
+print('Wrote solution to 2020-01-27_solution_from_text.json')

--- a/examples/scripts/EGRET_interface/ctminterface.py
+++ b/examples/scripts/EGRET_interface/ctminterface.py
@@ -19,7 +19,7 @@ import ctmsolution
 import egret.data.model_data as md
 import numpy as np
 
-def create_ModelData(ctm_filename):
+def create_ModelData(ctm_filename=None, ctm_json_str=None):
     """
     Parse JSON CTM input file into a ModelData object containing
     the model_data dictionary
@@ -28,12 +28,14 @@ def create_ModelData(ctm_filename):
     ----------
     ctm_filename : str
         Path and filename of the CTM input file you wish to load
+    ctm_json_str : str
+        CTM JSON string you wish to load
 
     Returns
     -------
         ModelData
     """
-    data = create_model_data_dict(ctm_filename)
+    data = create_model_data_dict(ctm_filename, ctm_json_str)
     return md.ModelData(data)
 
 def write_solution(model_data_wsol, ctm_sol_filename):
@@ -109,7 +111,7 @@ def ctmdata_2_model_data_dict(ctm):
     # return model data object created
     return model_data
 
-def create_model_data_dict(ctm_filename):
+def create_model_data_dict(ctm_filename=None, ctm_json_str=None):
     """
     Parse a CTM JSON file into a model_data dictionary
 
@@ -117,6 +119,8 @@ def create_model_data_dict(ctm_filename):
     ----------
     ctm_filename : str
         Path and filename of the CTM input file you wish to load
+    ctm_json_str : str
+        CTM JSON string you wish to load
 
     Returns
     -------
@@ -124,10 +128,18 @@ def create_model_data_dict(ctm_filename):
                object.
     """
     
-    # read CTM data file
-    # PENDING: reading time series in different files
-    ctm = ctmdata.parse(ctm_filename)   # this uses the auto generated pydantic data classes for
-                                        # validating the CTM JSON file
+    # check input: either ctm_filename or ctm_json_str must not be None, but not both
+    if (ctm_filename == None and ctm_json_str == None) or \
+       (ctm_filename != None and ctm_json_str != None):
+        raise Exception('either ctm_filename or ctm_json_str must not be None, but not both')
+    
+    if ctm_filename != None:
+        # read CTM data file
+        ctm = ctmdata.parse(ctm_filename)   # this uses the auto generated pydantic data classes for
+                                            # validating the CTM JSON file
+    else:
+        # read CTM data string
+        ctm = ctmdata.parse_obj_as(ctmdata.CtmData, ctmdata.json.loads(ctm_json_str))
     
     # call conversion function and return
     data = ctmdata_2_model_data_dict(ctm)


### PR DESCRIPTION
Allows passing a JSON file as a string instead of a path to a file when creating EGRET models from CTM data.